### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: server
+        image: ttl.sh/frontend-demo-otus:5h
+        readinessProbe:
+            initialDelaySeconds: 5
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+              - name: "Cookie"
+                value: "X-Session-ID=x-readiness-probe"
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "placeholder"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "placeholder"
+        - name: CART_SERVICE_ADDR
+          value: "placeholder"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "placeholder"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "placeholder"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "placeholder"
+        - name: AD_SERVICE_ADDR
+          value: "placeholder"

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      tier: frontend
+      app: frontend
   template:
     metadata:
       labels:
-        tier: frontend
+        app: frontend
     spec:
       containers:
       - name: server

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: server
+        image: ttl.sh/frontend-demo-otus:7h
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "placeholder"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "placeholder"
+        - name: CART_SERVICE_ADDR
+          value: "placeholder"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "placeholder"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "placeholder"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "placeholder"
+        - name: AD_SERVICE_ADDR
+          value: "placeholder"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      tier: frontend
+      app: frontend
   template:
     metadata:
       labels:
-        tier: frontend
+        app: frontend
     spec:
       containers:
       - name: server

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      tier: node-exporter
+  template:
+    metadata:
+      labels:
+        tier: node-exporter
+      annotations:
+         prometheus.io/scrape: "true"
+         prometheus.io/port: "9100"
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      containers:
+        - name: node-exporter
+          image: prom/node-exporter
+          securityContext:
+            privileged: true
+          args:
+#            - --collector.sysfs
+#            - --collector.filesystem.ignored-mount-points
+#            - '"^/(sys|proc|dev|host|etc)($|/)"'
+          ports:
+            - containerPort: 9100
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 100Mi
+          volumeMounts:
+            - name: dev
+              mountPath: /host/dev
+            - name: proc
+              mountPath: /host/proc
+            - name: sys
+              mountPath: /host/sys
+            - name: rootfs
+              mountPath: /rootfs
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: rootfs
+          hostPath:
+            path: /

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+        type: RollingUpdate
+        rollingUpdate:
+           maxSurge: 25%
+           maxUnavailable: 25%
+  selector:
+    matchLabels:
+      tier: paymentservice
+  template:
+    metadata:
+      labels:
+        tier: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: ttl.sh/otus-demo-paymentsrv:5h
+        env:
+        - name : PORT
+          value: "9000"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -13,11 +13,11 @@ spec:
            maxUnavailable: 25%
   selector:
     matchLabels:
-      tier: paymentservice
+      app: paymentservice
   template:
     metadata:
       labels:
-        tier: paymentservice
+        app: paymentservice
     spec:
       containers:
       - name: paymentservice

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 1
+  strategy:
+        type: Recreate
+  selector:
+    matchLabels:
+      tier: paymentservice
+  template:
+    metadata:
+      labels:
+        tier: paymentservice
+    spec:
+      containers:
+      - name: paymentsrv
+        image: ttl.sh/otus-demo-paymentsrv:7h
+        env:
+        - name : PORT
+          value: "9000"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -10,11 +10,11 @@ spec:
         type: Recreate
   selector:
     matchLabels:
-      tier: paymentservice
+      app: paymentservice
   template:
     metadata:
       labels:
-        tier: paymentservice
+        app: paymentservice
     spec:
       containers:
       - name: paymentsrv

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: paymentservice
+  template:
+    metadata:
+      labels:
+        tier: paymentservice
+    spec:
+      containers:
+      - name: paymentsrv
+        image: ttl.sh/otus-demo-paymentsrv:5h
+        env:
+        - name : PORT
+          value: "9000"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      tier: paymentservice
+      app: paymentservice
   template:
     metadata:
       labels:
-        tier: paymentservice
+        app: paymentservice
     spec:
       containers:
       - name: paymentsrv

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentsrv
+  labels:
+    app: paymentsrv
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: paymentsrv
+  template:
+    metadata:
+      labels:
+        tier: paymentsrv
+    spec:
+      containers:
+      - name: paymentsrv
+        image: ttl.sh/otus-demo-paymentsrv:5h
+        env:
+        - name : PORT
+          value: "9000"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -8,11 +8,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      tier: paymentsrv
+      app: paymentsrv
   template:
     metadata:
       labels:
-        tier: paymentsrv
+        app: paymentsrv
     spec:
       containers:
       - name: paymentsrv


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ + ] Основное ДЗ
 - [ + ] Задание со * и **

## В процессе сделано:
 - Обновление ReplicaSet не поддерживает RollingUpdate и поэтому образ не обновляется. Пока kuber видит что необходимое колво реплик живо ничего не сделает. Надо удалить все поды, тогда обновится, либо использовать deployment.
 - Первая *: используем strategy: type: RollingUpdate для BG и Recreate для Reverse
 - Вторая *: daemonset для node-exporter. Тестировал на MacOS, потому не все метрики доступны и не использовал стандартные аргументы запуск (но тут наверное и не надо).
 - **: По-умолчанию master ноды tainted и на них не запускаются daemonset. Использую в манифесте tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
(operator: Exists дефолтный не указывал)

## Как запустить проект:
 - kubectl apply ***

## Как проверить работоспособность:
 - kubectl get ***

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
 - [ ] Выставлен label Review Required для проверки advanced заданий
