### PR TITLE
kubernetes gitops files

### DIFF
--- a/kubernetes-gitops/.gitlab-ci.yml
+++ b/kubernetes-gitops/.gitlab-ci.yml
@@ -1,0 +1,37 @@
+stages:
+  - gcloud
+  - build
+
+.common:
+  except: 
+    refs:
+      - flux-sync
+
+.docker-template:
+  image:
+    name: docker:stable
+  services:
+    - docker:dind
+
+gcloud:
+  extends: .common
+  stage: gcloud
+  image: google/cloud-sdk
+  allow_failure: true
+  script:
+    - base64 -d ${CI_PROJECT_DIR}/encoded_serviceaccount.json > ${CI_PROJECT_DIR}/encoded_serviceaccount2.json
+    - gcloud auth activate-service-account --key-file ${CI_PROJECT_DIR}/encoded_serviceaccount2.json
+    - gcloud config set compute/zone us-central1-a
+    - gcloud container clusters create demo --enable-autoupgrade --enable-autoscaling --min-nodes=3 --max-nodes=10 --num-nodes=5 --project=turnkey-banner-339407
+
+build:
+  extends: .docker-template
+  stage: build
+  allow_failure: true
+  script:
+    - cd src/$SRVPATH
+    - docker build . -f Dockerfile -t ttl.sh/otus-gitops-$SERVICE:49h
+    - docker push ttl.sh/otus-gitops-$SERVICE:49h
+
+include:
+  - '/pipeline/build.yml'

--- a/kubernetes-gitops/flux.values.yaml
+++ b/kubernetes-gitops/flux.values.yaml
@@ -1,0 +1,8 @@
+git:
+  url: git@gitlab.com:SuXarik/microservices-demo.git
+  path: deploy
+  branch: "main"
+  ciSkip: true	
+  pollInterval: 1m
+registry:
+  automationInterval: 1m

--- a/kubernetes-gitops/helm-operator.values.yaml
+++ b/kubernetes-gitops/helm-operator.values.yaml
@@ -1,0 +1,17 @@
+helm:
+  versions: v3
+git:
+  pollInterval: 1m
+  ssh:
+    secretName: flux-git-deploy
+
+chartsSyncInterval: 1m
+
+logReleaseDiffs:
+  true
+
+configureRepositories:
+  enable: true
+  repositories:
+    - name: stable
+      url: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - gitlab repo: https://gitlab.com/SuXarik/microservices-demo
 - (первая звездочка) сделано автоматическое развертывание кластера в gke (в .gitlab-ci.yaml)
 - (вторая звездочка) сборка и пуш образа в ttl.sh (шаг build в .gitlab-ci.yaml)
 - установлен fluxcd и helm-operator
 - сделаны деплои всех сервисов
 - установлен deprecated istio в gke
 `gcloud beta container clusters update CLUSTER_NAME \
    --update-addons=Istio=ENABLED --istio-config=auth=MTLS_PERMISSIVE`
 - установлен flagger
 - gateway.yaml и virtualService.yaml для frontend добавлены в helm chart
 - Сделан canary. Изначально не запускается потому что нет трафика и соответственно никак не сделать canary. Запускаем curl в цикле на external ip и повторяем
 - kubectl describe canary
 <img width="1396" alt="Screenshot 2022-03-10 at 15 30 23" src="https://user-images.githubusercontent.com/96593062/157833860-f666bac3-8613-4e90-8ed4-57a58361e62c.png">
 - kubectl get canaries
 <img width="1409" alt="Screenshot 2022-03-10 at 15 32 18" src="https://user-images.githubusercontent.com/96593062/157834192-d0bde9fb-996b-42bf-a9e5-5e99b1f56fe7.png">

-   (Еще звездочка) добавлена канарейка для adservice по grpc. Все тоже самое.
-   (Еще звездочка) алерты в slack. Настраиваем webhook в slack, делаем upgrade flagger:
` helm upgrade -i flagger flagger/flagger --set slack.url=https://hooks.slack.com/services/******** --set slack.channel=general --set slack.user=flagger --namespace=istio-system`
  <img width="865" alt="Screenshot 2022-03-10 at 16 18 43" src="https://user-images.githubusercontent.com/96593062/157833707-a2c373f8-4c42-4aab-b4ff-855d73af436f.png">

-  (Снова звезда) инфраструктурный репозиторий. Не стал изобретать велосипед, разобрался с уже готовой отличной реализацией: https://github.com/stefanprodan/gitops-istio
-  (Еще звезда) jaeger:
 <img width="823" alt="Screenshot 2022-03-11 at 11 59 34" src="https://user-images.githubusercontent.com/96593062/157835512-3d316ebc-e149-4146-bc52-284f8058739b.png">
`$ kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/jaeger.yaml`
Для получения трейсов из самих микросервисов (кроме injector) добавляем JAEGER_SERVICE_ADDR = jaeger-collector.istio-system.svc.cluster.local:14268 в ENV манифестов микросервисов

-  (Две звезды) монорепы хороши были во времена монолитов, сейчас смысла пилить микросервисы по отдельным репам (когда у них и деплои и билды практически всегда одинаковы) смысла не вижу. Но все равно сделал для adservice монорепо со сборкой и деплоем в gke: https://gitlab.com/SuXarik/adservice

-  (Две звезды) argocd. Выглядит красиво, наверное удобно если полностью придерживаться подхода gitops. Пока в реальности не получится. Сделал демо для запуска nginx: https://gitlab.com/SuXarik/argotest
(запуск в minikube, установка самого argocd тривиальна и описана в офф доке)

<img width="1266" alt="Screenshot 2022-03-11 at 12 06 30" src="https://user-images.githubusercontent.com/96593062/157836690-2bdf5df4-46aa-46e3-9353-8a3731ea75c3.png">
 - 
## Как запустить проект:
 - О gitlab

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
