### PR TITLE
kubernetes debug files

### DIFF
--- a/kubernetes-debug/kit/cluster-role-iptables.yaml
+++ b/kubernetes-debug/kit/cluster-role-iptables.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]

--- a/kubernetes-debug/kit/cluster-rolebinding-iptables.yaml
+++ b/kubernetes-debug/kit/cluster-rolebinding-iptables.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/iptables.yaml
+++ b/kubernetes-debug/kit/iptables.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: "DaemonSet"
+metadata: 
+  name: "kube-iptables-tailer"
+  namespace: "kube-system"
+spec: 
+  selector:
+    matchLabels:
+      app: "kube-iptables-tailer" 
+  template:
+    metadata:
+      labels:
+        app: "kube-iptables-tailer"
+    spec: 
+      serviceAccountName: kube-iptables-tailer
+      containers: 
+        - name: "kube-iptables-tailer"
+          command:
+            - "/kube-iptables-tailer"
+            - "--log_dir=/my-service-logs" # change the output directory of service logs
+            - "--v=4" # enable V-leveled logging at this level
+          env: 
+            - name: "JOURNAL_DIRECTORY"
+              value: "/var/log/journal"
+          #for star 
+            - name: "POD_IDENTIFIER"
+              value: "name"
+            - name: "IPTABLES_LOG_PREFIX"
+              # log prefix defined in your iptables chains
+              value: "calico-packet:"
+          image: "virtualshuric/kube-iptables-tailer:8d4296a"
+          imagePullPolicy: Always
+          volumeMounts: 
+            - name: "iptables-logs"
+              mountPath: "/var/log/"
+              readOnly: true
+            - name: "service-logs"
+              mountPath: "/my-service-logs"
+      
+      volumes:
+        - name: "iptables-logs"
+          hostPath: 
+            # absolute path of the directory containing iptables log file on your host
+            path: "/var/log"
+        - name: "service-logs"
+          emptyDir: {}

--- a/kubernetes-debug/kit/netperf/calico-allow.yaml
+++ b/kubernetes-debug/kit/netperf/calico-allow.yaml
@@ -1,0 +1,22 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: app == "netperf-operator"
+      # selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: app == "netperf-operator" 
+      # selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/kit/netperf/cr-nodes.yaml
+++ b/kubernetes-debug/kit/netperf/cr-nodes.yaml
@@ -1,0 +1,7 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"
+spec:
+  serverNode: "minikube"
+  clientNode: "minikube"

--- a/kubernetes-debug/kit/netperf/cr.yaml
+++ b/kubernetes-debug/kit/netperf/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/netperf/crd.yaml
+++ b/kubernetes-debug/kit/netperf/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/netperf/operator.yaml
+++ b/kubernetes-debug/kit/netperf/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: majorinche/netperf-operator:2.8
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/netperf/rbac.yaml
+++ b/kubernetes-debug/kit/netperf/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/service-acc-iptables.yaml
+++ b/kubernetes-debug/kit/service-acc-iptables.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: default

--- a/kubernetes-debug/strace/agent.yaml
+++ b/kubernetes-debug/strace/agent.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate

--- a/kubernetes-debug/strace/nginx.yaml
+++ b/kubernetes-debug/strace/nginx.yaml
@@ -1,0 +1,8 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Делал на minikube kuber 1.17, на latest оператор даже не поднимался
 - Сразу правим apiVersion и применяем kubectl apply -f strace/agent.yaml
 - Применяем kubectl apply -f strace/nginx.yaml
 - Ничего не пашет потому что нет capabilites
 - Правим версию образа на latest и теперь у нас есть     "SYS_PTRACE",   "SYS_ADMIN"
 - kubectl-debug nginx --agentless=false --port-forward=true -v=1 (без verbose тупит и не скачивает образ)
 - Теперь iptables
 - Ставим crd.yaml, rbac.yaml, operator.yaml из kit/netperf
 - Поскольку включен calico надо еще и его логирование включить kit/netperf/calico-allow.yaml
 - После чего kubectl describe netperf.app.example.com/example
 
<img width="1122" alt="Screenshot 2022-04-13 at 13 03 47" src="https://user-images.githubusercontent.com/96593062/163158529-74d8d868-fa31-4c28-9b50-f787abb0053b.png">

 - kubectl apply -f kit/iptables.yaml (не запустится, нужны rbac)
 - kit/service-acc-iptables.yaml, kit/cluster-role-iptables.yaml, kit/cluster-rolebinding-iptables.yaml
 - Пересоздаем kit/nperf/cr.yaml
 
<img width="1123" alt="Screenshot 2022-04-13 at 13 13 51" src="https://user-images.githubusercontent.com/96593062/163159258-93003627-5204-4dcc-99a2-aeec3021d500.png">

 - Звездочка правим NetworkPolicy
```
  selector: app == "netperf-operator"
  ingress:
    - action: Allow
      source:
        selector: app == "netperf-operator"
      # selector: netperf-role == "netperf-client"
    - action: Log
    - action: Deny
  egress:
    - action: Allow
      destination:
        selector: app == "netperf-operator" 
      # selector: netperf-role == "netperf-client"
    - action: Log
    - action: Deny
```
 - Звезда, отображение имен подов
```
 env:
  - name: "POD_IDENTIFIER"
    value: "name"
```
P.S.  оператор какой-то падучий и глючный, 4 года без изменений, пора переходить на что-то поновее

Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
